### PR TITLE
Increase file size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,10 @@ This is an extension brought by [jsoncrack.com](https://jsoncrack.com).
 3. Press **F5** to debug
 
 For every change at codebase you should re-do the steps **2 and 3**.
+
+### Configuration
+
+The extension prevents extremely large files from being visualized. By default,
+files larger than **5&nbsp;MB** are not processed. You can override this value by
+setting the `NEXT_PUBLIC_FILE_SIZE_LIMIT_MB` environment variable before running
+`pnpm build`.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For every change at codebase you should re-do the steps **2 and 3**.
 ### Configuration
 
 The extension prevents extremely large files from being visualized. By default,
-files larger than **5&nbsp;MB** are not processed. You can override this value by
-setting the `NEXT_PUBLIC_FILE_SIZE_LIMIT_MB` environment variable before running
-`pnpm build`.
+files larger than **5&nbsp;MB** or JSON graphs with more than **1000** nodes are
+not processed. You can override these values by setting the
+`NEXT_PUBLIC_FILE_SIZE_LIMIT_MB` and `NEXT_PUBLIC_NODE_LIMIT` environment
+variables before running `pnpm build`.

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
   },
   "dependencies": {
     "eslint-plugin-unused-imports": "^4.1.4",
+    "lodash.debounce": "^4.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "reaflow": "5.2.11",

--- a/src/jsoncrack/constants.ts
+++ b/src/jsoncrack/constants.ts
@@ -1,0 +1,3 @@
+export const NODE_LIMIT = +(process.env.NEXT_PUBLIC_NODE_LIMIT as string) || 1000;
+export const FILE_SIZE_LIMIT_BYTES =
+  (+(process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT_MB as string) || 5) * 1024 * 1024;

--- a/src/jsoncrack/features/editor/views/GraphView/NotSupported.tsx
+++ b/src/jsoncrack/features/editor/views/GraphView/NotSupported.tsx
@@ -143,7 +143,7 @@ export const NotSupported = () => {
     <StyledNotSupported>
       <StyledContent>
         <Text c="dimmed" maw="400" my="lg" ta="center">
-          JSON Crack is unable to support data of this size. Please try our new editor for better
+          JSON Crack is unable to support data above the default 5&nbsp;MB limit. Please try our new editor for better
           performance.
         </Text>
         <Button

--- a/src/jsoncrack/features/editor/views/GraphView/NotSupported.tsx
+++ b/src/jsoncrack/features/editor/views/GraphView/NotSupported.tsx
@@ -143,7 +143,7 @@ export const NotSupported = () => {
     <StyledNotSupported>
       <StyledContent>
         <Text c="dimmed" maw="400" my="lg" ta="center">
-          JSON Crack is unable to support data above the default 5&nbsp;MB limit. Please try our new editor for better
+          JSON Crack is unable to support data above the default 5&nbsp;MB or 1000 node limit. Please try our new editor for better
           performance.
         </Text>
         <Button

--- a/src/jsoncrack/features/editor/views/GraphView/index.tsx
+++ b/src/jsoncrack/features/editor/views/GraphView/index.tsx
@@ -12,6 +12,7 @@ import { CustomEdge } from "./CustomEdge";
 import { CustomNode } from "./CustomNode";
 import useGraph from "./stores/useGraph";
 import useFile from "../../../../store/useFile";
+import useJson from "../../../../store/useJson";
 import { FileFormat } from "../../../../enums/file.enum";
 import { NotSupported } from "./NotSupported";
 
@@ -152,12 +153,18 @@ const GraphCanvas = ({ isWidget }: GraphProps) => {
   );
 };
 
-const SUPPORTED_LIMIT = +(process.env.NEXT_PUBLIC_NODE_LIMIT as string) || 1000;
+const SUPPORTED_NODE_LIMIT =
+  +(process.env.NEXT_PUBLIC_NODE_LIMIT as string) || 1000;
+const SUPPORTED_FILE_LIMIT =
+  (+(process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT_MB as string) || 5) * 1024 * 1024;
 
 export const GraphView = ({ isWidget = false, json }: GraphProps) => {
   const setViewPort = useGraph((state) => state.setViewPort);
   const viewPort = useGraph((state) => state.viewPort);
-  const aboveSupportedLimit = useGraph(state => state.nodes.length > SUPPORTED_LIMIT);
+  const aboveSupportedLimit = useGraph(
+    state => state.nodes.length > SUPPORTED_NODE_LIMIT
+  );
+  const fileTooLarge = useJson(state => state.overSizeLimit);
   const loading = useGraph((state) => state.loading);
   const gesturesEnabled = useConfig((state) => state.gesturesEnabled);
   const rulersEnabled = useConfig((state) => state.rulersEnabled);
@@ -195,7 +202,7 @@ export const GraphView = ({ isWidget = false, json }: GraphProps) => {
     }
   }, [json, setContents]);
 
-  if (aboveSupportedLimit) {
+  if (aboveSupportedLimit || fileTooLarge) {
     return <NotSupported />;
   }
 

--- a/src/jsoncrack/features/editor/views/GraphView/index.tsx
+++ b/src/jsoncrack/features/editor/views/GraphView/index.tsx
@@ -15,6 +15,7 @@ import useFile from "../../../../store/useFile";
 import useJson from "../../../../store/useJson";
 import { FileFormat } from "../../../../enums/file.enum";
 import { NotSupported } from "./NotSupported";
+import { NODE_LIMIT, FILE_SIZE_LIMIT_BYTES } from "../../../../constants";
 
 const StyledEditorWrapper = styled.div<{
   $widget: boolean;
@@ -153,10 +154,8 @@ const GraphCanvas = ({ isWidget }: GraphProps) => {
   );
 };
 
-const SUPPORTED_NODE_LIMIT =
-  +(process.env.NEXT_PUBLIC_NODE_LIMIT as string) || 1000;
-const SUPPORTED_FILE_LIMIT =
-  (+(process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT_MB as string) || 5) * 1024 * 1024;
+const SUPPORTED_NODE_LIMIT = NODE_LIMIT;
+const SUPPORTED_FILE_LIMIT = FILE_SIZE_LIMIT_BYTES;
 
 export const GraphView = ({ isWidget = false, json }: GraphProps) => {
   const setViewPort = useGraph((state) => state.setViewPort);
@@ -165,6 +164,7 @@ export const GraphView = ({ isWidget = false, json }: GraphProps) => {
     state => state.nodes.length > SUPPORTED_NODE_LIMIT
   );
   const fileTooLarge = useJson(state => state.overSizeLimit);
+  const nodeTooLarge = useJson(state => state.overNodeLimit);
   const loading = useGraph((state) => state.loading);
   const gesturesEnabled = useConfig((state) => state.gesturesEnabled);
   const rulersEnabled = useConfig((state) => state.rulersEnabled);
@@ -202,7 +202,7 @@ export const GraphView = ({ isWidget = false, json }: GraphProps) => {
     }
   }, [json, setContents]);
 
-  if (aboveSupportedLimit || fileTooLarge) {
+  if (aboveSupportedLimit || fileTooLarge || nodeTooLarge) {
     return <NotSupported />;
   }
 

--- a/src/jsoncrack/features/editor/views/GraphView/lib/jsonParser.ts
+++ b/src/jsoncrack/features/editor/views/GraphView/lib/jsonParser.ts
@@ -45,16 +45,20 @@ function initializeStates(): States {
   };
 }
 
-export function parser(jsonStr: string): Graph {
+export function parser(
+  jsonStr: string,
+  limit: number = Infinity
+  ): { graph: Graph; limitExceeded: boolean } {
   try {
     const states = initializeStates();
+    const limitExceeded = { current: false };
     const parsedJsonTree = parseTree(jsonStr);
 
     if (!parsedJsonTree) {
       throw new Error("Invalid document");
     }
 
-    traverse({ states, objectToTraverse: parsedJsonTree });
+    traverse({ states, objectToTraverse: parsedJsonTree, limit, limitExceeded });
 
     const { notHaveParent, graph } = states;
 
@@ -78,9 +82,9 @@ export function parser(jsonStr: string): Graph {
       path: getNodePath(states.graph.nodes, states.graph.edges, node.id),
     }));
 
-    return states.graph;
+    return { graph: states.graph, limitExceeded: limitExceeded.current };
   } catch (error) {
     console.error(error);
-    return { nodes: [], edges: [] };
+    return { graph: { nodes: [], edges: [] }, limitExceeded: false };
   }
 }

--- a/src/jsoncrack/features/editor/views/GraphView/lib/utils/traverse.ts
+++ b/src/jsoncrack/features/editor/views/GraphView/lib/utils/traverse.ts
@@ -12,6 +12,8 @@ type Traverse = {
   parentType?: string;
   myParentId?: string;
   nextType?: string;
+  limit?: number;
+  limitExceeded?: { current: boolean };
 };
 
 const isPrimitiveOrNullType = (type: unknown): type is PrimitiveOrNullType => {
@@ -35,8 +37,11 @@ function handleNoChildren(
   graph: Graph,
   myParentId?: string,
   parentType?: string,
-  nextType?: string
+  nextType?: string,
+  limit?: number,
+  limitExceeded?: { current: boolean }
 ) {
+  if (limitExceeded?.current) return;
   if (value === undefined) return;
 
   if (parentType === "property" && nextType !== "object" && nextType !== "array") {
@@ -48,6 +53,10 @@ function handleNoChildren(
     }
   } else if (parentType === "array") {
     const nodeFromArrayId = addNodeToGraph({ graph, text: String(value) });
+    if (limit && graph.nodes.length > limit) {
+      limitExceeded && (limitExceeded.current = true);
+      return;
+    }
 
     if (myParentId) {
       addEdgeToGraph(graph, myParentId, nodeFromArrayId);
@@ -65,8 +74,11 @@ function handleHasChildren(
   graph: Graph,
   children: Node[],
   myParentId?: string,
-  parentType?: string
+  parentType?: string,
+  limit?: number,
+  limitExceeded?: { current: boolean }
 ) {
+  if (limitExceeded?.current) return;
   let parentId: string | undefined;
 
   if (type !== "property" && states.parentName !== "") {
@@ -97,6 +109,14 @@ function handleHasChildren(
         }
       } else {
         const brothersNodeId = addNodeToGraph({ graph, text: states.brothersNode });
+        if (limit && graph.nodes.length > limit) {
+          limitExceeded && (limitExceeded.current = true);
+          return;
+        }
+        if (limit && graph.nodes.length > limit) {
+          limitExceeded && (limitExceeded.current = true);
+          return;
+        }
 
         states.brothersNode = [];
 
@@ -116,6 +136,10 @@ function handleHasChildren(
 
     // Add parent node
     parentId = addNodeToGraph({ graph, type, text: states.parentName });
+    if (limit && graph.nodes.length > limit) {
+      limitExceeded && (limitExceeded.current = true);
+      return;
+    }
     states.bracketOpen.push({ id: parentId, type });
     states.parentName = "";
 
@@ -147,6 +171,8 @@ function handleHasChildren(
       parentType: type,
       myParentId: states.bracketOpen[states.bracketOpen.length - 1]?.id,
       nextType,
+      limit,
+      limitExceeded,
     });
   };
 
@@ -155,6 +181,7 @@ function handleHasChildren(
       const nextType = array[index + 1]?.type;
 
       traverseObject(objectToTraverse, nextType);
+      if (limitExceeded?.current) return;
     });
   };
 
@@ -191,6 +218,10 @@ function handleHasChildren(
         }
       } else {
         const brothersNodeId = addNodeToGraph({ graph, text: states.brothersNode });
+        if (limit && graph.nodes.length > limit) {
+          limitExceeded && (limitExceeded.current = true);
+          return;
+        }
 
         states.brothersNode = [];
 
@@ -243,13 +274,34 @@ export const traverse = ({
   myParentId,
   nextType,
   parentType,
+  limit,
+  limitExceeded,
 }: Traverse) => {
+  if (limitExceeded?.current) return;
   const graph = states.graph;
   const { type, children, value } = objectToTraverse;
 
   if (!children) {
-    handleNoChildren(value, states, graph, myParentId, parentType, nextType);
+    handleNoChildren(
+      value,
+      states,
+      graph,
+      myParentId,
+      parentType,
+      nextType,
+      limit,
+      limitExceeded
+    );
   } else if (children) {
-    handleHasChildren(type, states, graph, children, myParentId, parentType);
+    handleHasChildren(
+      type,
+      states,
+      graph,
+      children,
+      myParentId,
+      parentType,
+      limit,
+      limitExceeded
+    );
   }
 };

--- a/src/jsoncrack/features/editor/views/GraphView/stores/useGraph.ts
+++ b/src/jsoncrack/features/editor/views/GraphView/stores/useGraph.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import useJson from "../../../../../store/useJson";
 import type { EdgeData, NodeData } from "../../../../../types/graph";
 import { parser } from "../lib/jsonParser";
+import { NODE_LIMIT } from "../../../../constants";
 import { getChildrenEdges } from "../lib/utils/getChildrenEdges";
 import { getOutgoers } from "../lib/utils/getOutgoers";
 
@@ -72,7 +73,17 @@ const useGraph = create<Graph & GraphActions>((set, get) => ({
   getCollapsedEdgeIds: () => get().collapsedEdges,
   setSelectedNode: nodeData => set({ selectedNode: nodeData }),
   setGraph: (data, options) => {
-    const { nodes, edges } = parser(data ?? useJson.getState().json);
+    const { graph, limitExceeded } = parser(
+      data ?? useJson.getState().json,
+      NODE_LIMIT
+    );
+    const { nodes, edges } = graph;
+
+    if (limitExceeded) {
+      useJson.getState().setOverNodeLimit(true);
+      set({ nodes: [], edges: [], loading: false });
+      return;
+    }
 
     if (get().collapseAll) {
       set({ nodes, edges, ...options });

--- a/src/jsoncrack/store/useJson.ts
+++ b/src/jsoncrack/store/useJson.ts
@@ -1,16 +1,19 @@
 import { create } from "zustand";
 import useGraph from "../features/editor/views/GraphView/stores/useGraph";
+import { FILE_SIZE_LIMIT_BYTES } from "../constants";
 
 interface JsonActions {
   setJson: (json: string) => void;
   getJson: () => string;
   clear: () => void;
+  setOverNodeLimit: (value: boolean) => void;
 }
 
 const initialStates = {
   json: "",
   loading: true,
   overSizeLimit: false,
+  overNodeLimit: false,
 };
 
 export type JsonStates = typeof initialStates;
@@ -19,12 +22,9 @@ const useJson = create<JsonStates & JsonActions>()((set, get) => ({
   ...initialStates,
   getJson: () => get().json,
   setJson: json => {
-    const SIZE_LIMIT =
-      (+(process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT_MB as string) || 5) *
-      1024 * 1024;
-    const overLimit = json.length > SIZE_LIMIT;
+    const overLimit = json.length > FILE_SIZE_LIMIT_BYTES;
 
-    set({ json, loading: false, overSizeLimit: overLimit });
+    set({ json, loading: false, overSizeLimit: overLimit, overNodeLimit: false });
 
     if (overLimit) {
       useGraph.getState().clearGraph();
@@ -40,9 +40,10 @@ const useJson = create<JsonStates & JsonActions>()((set, get) => ({
     }
   },
   clear: () => {
-    set({ json: "", loading: false, overSizeLimit: false });
+    set({ json: "", loading: false, overSizeLimit: false, overNodeLimit: false });
     useGraph.getState().clearGraph();
   },
+  setOverNodeLimit: value => set({ overNodeLimit: value }),
 }));
 
 export default useJson;

--- a/src/jsoncrack/store/useJson.ts
+++ b/src/jsoncrack/store/useJson.ts
@@ -10,6 +10,7 @@ interface JsonActions {
 const initialStates = {
   json: "",
   loading: true,
+  overSizeLimit: false,
 };
 
 export type JsonStates = typeof initialStates;
@@ -18,11 +19,28 @@ const useJson = create<JsonStates & JsonActions>()((set, get) => ({
   ...initialStates,
   getJson: () => get().json,
   setJson: json => {
-    set({ json, loading: false });
-    useGraph.getState().setGraph(json);
+    const SIZE_LIMIT =
+      (+(process.env.NEXT_PUBLIC_FILE_SIZE_LIMIT_MB as string) || 5) *
+      1024 * 1024;
+    const overLimit = json.length > SIZE_LIMIT;
+
+    set({ json, loading: false, overSizeLimit: overLimit });
+
+    if (overLimit) {
+      useGraph.getState().clearGraph();
+      return;
+    }
+
+    const parse = () => useGraph.getState().setGraph(json);
+
+    if (typeof (window as any).requestIdleCallback === "function") {
+      (window as any).requestIdleCallback(parse);
+    } else {
+      setTimeout(parse, 0);
+    }
   },
   clear: () => {
-    set({ json: "", loading: false });
+    set({ json: "", loading: false, overSizeLimit: false });
     useGraph.getState().clearGraph();
   },
 }));


### PR DESCRIPTION
## Summary
- allow up to 5MB JSON files by default
- skip parsing if file exceeds limit
- parse JSON asynchronously to keep UI responsive
- update unsupported message and docs
- add lodash.debounce dependency

## Testing
- `pnpm install`
- `pnpm build` *(fails: Module not found / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6877e9bd0484832b9b126ee5ba182d89